### PR TITLE
feat: Add Laravel 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Pages for Laravel and Nova
 Drop-in functionality for site menus in Laravel and Nova.
 
+## Supported Versions
+
+| Laravel | Nova | This Package |
+|---------|------|-------------|
+| 10.x   | 4.x / 5.x | latest |
+| 11.x   | 4.x / 5.x | latest |
+| 12.x   | 4.x / 5.x | latest |
+| 13.x   | 4.x / 5.x | latest |
+
 ## Installation & Customization
 ### Standard
 If you are creating a simple app, these two steps should suffice. However, if

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "genealabs/laravel-overridable-model": "*",
-        "illuminate/support": "^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "laravel/nova": "^4.0|^5.0",
         "optimistdigital/nova-sortable": "*",
         "symfony/thanks": "^1.2"


### PR DESCRIPTION
Fixes: #1

## Changes
- Updated `illuminate/support` version constraint from `^10.0|^11.0|^12.0` to `^10.0|^11.0|^12.0|^13.0`
- Added version support table to README documenting Laravel 10-13 compatibility

## Notes
- Reviewed all source files for Laravel 13 breaking changes — none found. The package uses standard Laravel APIs (ServiceProvider, Blade components, Eloquent models, migrations) that remain compatible.
- No CI workflow exists in this repo, so no matrix update was needed.