### PR TITLE
feat: Add PHP 8.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4', '8.5']
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        run: vendor/bin/phpunit --no-coverage
+        if: hashFiles('phpunit.xml') != '' || hashFiles('phpunit.xml.dist') != ''

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Pages for Laravel and Nova
 Drop-in functionality for site menus in Laravel and Nova.
 
+## Version Support
+
+| PHP | Laravel | Nova |
+|-----|---------|------|
+| 8.5 | 10–12  | 4–5  |
+| 8.4 | 10–12  | 4–5  |
+| 8.3 | 10–12  | 4–5  |
+| 8.2 | 10–12  | 4–5  |
+
 ## Installation & Customization
 ### Standard
 If you are creating a simple app, these two steps should suffice. However, if

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         }
     ],
     "require": {
+        "php": "^8.2",
         "genealabs/laravel-overridable-model": "*",
         "illuminate/support": "^10.0|^11.0|^12.0",
         "laravel/nova": "^4.0|^5.0",


### PR DESCRIPTION
Fixes: #2

## Changes

- Added `php: ^8.2` constraint to `composer.json` (covers PHP 8.2 through 8.5)
- Created CI workflow (`.github/workflows/tests.yml`) with PHP 8.2, 8.3, 8.4, and 8.5 matrix
- Added version support table to README

## Acceptance Criteria

- [x] `composer.json` version constraint updated to include PHP 8.5
- [x] CI matrix includes a PHP 8.5 job
- [x] No PHP 8.5 deprecation warnings or compatibility issues found in source
- [x] README version support table updated to include PHP 8.5